### PR TITLE
[DOC] Comment out CLANG related options

### DIFF
--- a/doxygen/seqan3_doxygen_cfg.in
+++ b/doxygen/seqan3_doxygen_cfg.in
@@ -1079,7 +1079,7 @@ VERBATIM_HEADERS       = YES
 # generated with the -Duse-libclang=ON option for CMake.
 # The default value is: NO.
 
-CLANG_ASSISTED_PARSING = NO
+# CLANG_ASSISTED_PARSING = NO
 
 # If clang assisted parsing is enabled you can provide the compiler with command
 # line options that you would normally use when invoking the compiler. Note that
@@ -1087,7 +1087,7 @@ CLANG_ASSISTED_PARSING = NO
 # specified with INPUT and INCLUDE_PATH.
 # This tag requires that the tag CLANG_ASSISTED_PARSING is set to YES.
 
-CLANG_OPTIONS          =
+# CLANG_OPTIONS          =
 
 #---------------------------------------------------------------------------
 # Configuration options related to the alphabetical class index


### PR DESCRIPTION
Even if set to NO it will throw a warning when compiling the docs